### PR TITLE
The functionality of the "clear" and "select" buttons has been returned

### DIFF
--- a/samples/SampleApp/Views/CalendarPickerPopup.xaml
+++ b/samples/SampleApp/Views/CalendarPickerPopup.xaml
@@ -59,7 +59,7 @@
                     HorizontalOptions="Center"
                     MaximumDate="{Binding MaximumDate, Mode=OneWay}"
                     MinimumDate="{Binding MinimumDate, Mode=OneWay}"
-                    SelectedDate="{Binding SelectedDate, Mode=OneWay}"
+                    SelectedDate="{Binding SelectedDate, Mode=TwoWay}"
                     ShownDate="{Binding ShownDate, Mode=OneWay}"
                     VerticalOptions="Center"
                     WidthRequest="320" />

--- a/samples/SampleApp/Views/CalendarRangePickerPopup.xaml
+++ b/samples/SampleApp/Views/CalendarRangePickerPopup.xaml
@@ -63,8 +63,8 @@
                     MaximumDate="{Binding MaximumDate, Mode=OneWay}"
                     MinimumDate="{Binding MinimumDate, Mode=OneWay}"
                     ShownDate="{Binding ShownDate, Mode=OneWay}"                   
-                    SelectedEndDate="{Binding SelectedEndDate, Mode=OneWay}"
-                    SelectedStartDate="{Binding SelectedStartDate, Mode=OneWay}"
+                    SelectedEndDate="{Binding SelectedEndDate, Mode=TwoWay}"
+                    SelectedStartDate="{Binding SelectedStartDate, Mode=TwoWay}"
                     VerticalOptions="Center"
                     WidthRequest="320">
                     <plugin:Calendar.HeaderSectionTemplate>

--- a/samples/SampleApp/Views/CalendarRangePickerPopupSelectedDates.xaml
+++ b/samples/SampleApp/Views/CalendarRangePickerPopupSelectedDates.xaml
@@ -64,7 +64,7 @@
                     MaximumDate="{Binding MaximumDate, Mode=OneWay}"
                     MinimumDate="{Binding MinimumDate, Mode=OneWay}"
                     ShownDate="{Binding ShownDate, Mode=OneWay}"                    
-                    SelectedDates="{Binding SelectedDates, Mode=OneWay}"
+                    SelectedDates="{Binding SelectedDates, Mode=TwoWay}"
                     VerticalOptions="Center"
                     WidthRequest="320">
                     <plugin:Calendar.HeaderSectionTemplate>


### PR DESCRIPTION
**Description of Changes**

The functionality of the "clear" and "select" buttons on the Picker Popup pages has been restored by returning the "TwoMode" binding)