### PR TITLE
display up to five events per day

### DIFF
--- a/samples/SampleApp/Model/DayEventCollection.cs
+++ b/samples/SampleApp/Model/DayEventCollection.cs
@@ -5,7 +5,7 @@ namespace SampleApp.Model;
 /// <summary>
 /// Wrapper to allow change the dot color
 /// </summary>
-public class DayEventCollection<T> : List<T>, IPersonalizableDayEvent
+public class DayEventCollection<T> : List<T>, IPersonalizableDayEvent, IMultiEventDay
 {
     /// <summary>
     /// Empty contructor extends from base()
@@ -29,7 +29,8 @@ public class DayEventCollection<T> : List<T>, IPersonalizableDayEvent
     /// </summary>
     /// <param name="collection"></param>
     public DayEventCollection(IEnumerable<T> collection) : base(collection)
-    { }
+    { 
+    }
 
     /// <summary>
     /// Capacity contructor extends from base(int capacity)
@@ -44,5 +45,9 @@ public class DayEventCollection<T> : List<T>, IPersonalizableDayEvent
     public Color? EventIndicatorTextColor { get; set; }
     public Color? EventIndicatorSelectedTextColor { get; set; }
 
+    #endregion
+
+    #region IMultiEventDay
+    public IReadOnlyList<Color> Colors { get; set; }
     #endregion
 }

--- a/samples/SampleApp/Model/EventModel.cs
+++ b/samples/SampleApp/Model/EventModel.cs
@@ -4,4 +4,5 @@ public class EventModel
 {
     public string Name { get; set; }
     public string Description { get; set; }
+    public Color Color { get; set; }
 }

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -53,17 +53,17 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.72" />		
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-		<PackageReference Include="Mopups" Version="1.3.1" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.92" />		
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+		<PackageReference Include="Mopups" Version="1.3.2" />
 	</ItemGroup>		
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\Plugin.Maui.Calendar\Plugin.Maui.Calendar.csproj" />
 	</ItemGroup>	
 	
 	<ItemGroup>
-	 <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.72" />
-	<PackageReference Include="CommunityToolkit.Maui" Version="9.0.3" />
+	 <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.92" />
+	<PackageReference Include="CommunityToolkit.Maui" Version="9.1.0" />
 	</ItemGroup>	
 	
 	<ItemGroup>

--- a/samples/SampleApp/ViewModels/SimplePageViewModel.cs
+++ b/samples/SampleApp/ViewModels/SimplePageViewModel.cs
@@ -11,12 +11,13 @@ public partial class SimplePageViewModel : BasePageViewModel
 
         // testing all kinds of adding events
         // when initializing collection
+        var threeEventsTommorrow = GenerateEvents( 3, "Simple3" ).ToArray();
         Events = new EventCollection
         {
             [DateTime.Now.AddDays(-3)] = new List<EventModel>(GenerateEvents(10, "Cool")),
             [DateTime.Now.AddDays(4)] = new List<EventModel>(GenerateEvents(2, "Simple2")),
             [DateTime.Now.AddDays(2)] = new List<EventModel>(GenerateEvents(1, "Simple1")),
-            [DateTime.Now.AddDays(1)] = new List<EventModel>(GenerateEvents(3, "Simple3")),
+            [DateTime.Now.AddDays(1)] = new DayEventCollection<EventModel>(threeEventsTommorrow){Colors=threeEventsTommorrow.Select(e=>e.Color).ToArray()},
         };
 
         // with add method
@@ -60,7 +61,8 @@ public partial class SimplePageViewModel : BasePageViewModel
         return Enumerable.Range(1, count).Select(x => new EventModel
         {
             Name = $"{name} event{x}",
-            Description = $"This is {name} event{x}'s description!"
+            Description = $"This is {name} event{x}'s description!",
+            Color = Color.FromInt( (int)(0xff000000 | Random.Shared.Next( 0xffffff )) ),
         });
     }
 

--- a/src/Plugin.Maui.Calendar/Plugin.Maui.Calendar.csproj
+++ b/src/Plugin.Maui.Calendar/Plugin.Maui.Calendar.csproj
@@ -46,13 +46,13 @@
 	  <CreatePackage>false</CreatePackage>
 	</PropertyGroup>
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.72" />		
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.92" />		
 	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	    <PrivateAssets>all</PrivateAssets>
 	  </PackageReference>
-	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
-	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.72" />
+	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.92" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Remove="Shared\" />

--- a/src/Plugin.Maui.Calendar/Shared/Controls/DayView.xaml
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/DayView.xaml
@@ -42,7 +42,7 @@
                 Style="{Binding DaysLabelStyle, Mode=OneWay}"
                 Text="{Binding Date.Day, Mode=OneWay}"
                 TextColor="{Binding TextColor, Mode=OneWay}" />
-            <StackLayout Orientation="Horizontal" HeightRequest="8">
+            <HorizontalStackLayout HeightRequest="8">
                 <Border
                     Padding="0"
                     BackgroundColor="{Binding EventColor, Mode=OneWay}"
@@ -78,7 +78,7 @@
                     IsVisible="{Binding IsFifthEventDotVisible, Mode=OneWay}"
                     StrokeShape="RoundRectangle 4"
                     WidthRequest="8" />
-            </StackLayout>
+            </HorizontalStackLayout>
         </FlexLayout>
     </Grid>
 </ContentView>

--- a/src/Plugin.Maui.Calendar/Shared/Controls/DayView.xaml
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/DayView.xaml
@@ -13,15 +13,22 @@
             <conv:StrokeShapeConverter x:Key="StrokeShapeConverter" />
         </ResourceDictionary>
     </ContentView.Resources>
-    <Border
+    <Grid
+        Padding="0"
+        Margin="0"
+        IsVisible="{Binding IsVisible, Mode=OneWay}">
+        <Border
         Padding="0"
         BackgroundColor="{Binding BackgroundColor, Mode=OneWay}"
         HeightRequest="{Binding DayViewSize, Mode=OneWay}"
         HorizontalOptions="Center"
-        IsVisible="{Binding IsVisible, Mode=OneWay}"
         Stroke="{Binding OutlineColor, Mode=OneWay}"
         StrokeShape="{Binding DayViewCornerRadius, Converter={StaticResource StrokeShapeConverter}, Mode=OneWay}"
         WidthRequest="{Binding DayViewSize, Mode=OneWay}">
+            <Border.GestureRecognizers>
+                <TapGestureRecognizer Tapped="OnTapped" />
+            </Border.GestureRecognizers>
+        </Border>
         <FlexLayout
             AlignItems="Center"
             Direction="{Binding EventLayoutDirection}"
@@ -32,17 +39,44 @@
                 Style="{Binding DaysLabelStyle, Mode=OneWay}"
                 Text="{Binding Date.Day, Mode=OneWay}"
                 TextColor="{Binding TextColor, Mode=OneWay}" />
-            <Border
-                Padding="0"
-                BackgroundColor="{Binding EventColor, Mode=OneWay}"
-                HeightRequest="8"
-                IsVisible="{Binding IsEventDotVisible, Mode=OneWay}"
-                StrokeShape="RoundRectangle 4"
-                WidthRequest="8" />
+            <StackLayout Orientation="Horizontal">
+                <Border
+                    Padding="0"
+                    BackgroundColor="{Binding EventColor, Mode=OneWay}"
+                    HeightRequest="8"
+                    IsVisible="{Binding IsEventDotVisible, Mode=OneWay}"
+                    StrokeShape="RoundRectangle 4"
+                    WidthRequest="8" />
+                <Border
+                    Padding="0"
+                    BackgroundColor="{Binding SecondEventColor, Mode=OneWay}"
+                    HeightRequest="8"
+                    IsVisible="{Binding IsSecondEventDotVisible, Mode=OneWay}"
+                    StrokeShape="RoundRectangle 4"
+                    WidthRequest="8" />
+                <Border
+                    Padding="0"
+                    BackgroundColor="{Binding ThirdEventColor, Mode=OneWay}"
+                    HeightRequest="8"
+                    IsVisible="{Binding IsThirdEventDotVisible, Mode=OneWay}"
+                    StrokeShape="RoundRectangle 4"
+                    WidthRequest="8" />
+                <Border
+                    Padding="0"
+                    BackgroundColor="{Binding FourthEventColor, Mode=OneWay}"
+                    HeightRequest="8"
+                    IsVisible="{Binding IsFourthEventDotVisible, Mode=OneWay}"
+                    StrokeShape="RoundRectangle 4"
+                    WidthRequest="8" />
+                <Border
+                    Padding="0"
+                    BackgroundColor="{Binding FifthEventColor, Mode=OneWay}"
+                    HeightRequest="8"
+                    IsVisible="{Binding IsFifthEventDotVisible, Mode=OneWay}"
+                    StrokeShape="RoundRectangle 4"
+                    WidthRequest="8" />
+            </StackLayout>
         </FlexLayout>
-        <Border.GestureRecognizers>
-            <TapGestureRecognizer Tapped="OnTapped" />
-        </Border.GestureRecognizers>
-    </Border>
+    </Grid>
 </ContentView>
 

--- a/src/Plugin.Maui.Calendar/Shared/Controls/DayView.xaml
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/DayView.xaml
@@ -16,6 +16,8 @@
     <Grid
         Padding="0"
         Margin="0"
+        HeightRequest="{Binding DayViewSize, Mode=OneWay}"
+        WidthRequest="{Binding DayViewSize, Mode=OneWay}"
         IsVisible="{Binding IsVisible, Mode=OneWay}">
         <Border
         Padding="0"
@@ -33,13 +35,14 @@
             AlignItems="Center"
             Direction="{Binding EventLayoutDirection}"
             JustifyContent="Center">
+            <Grid HeightRequest="4"/>
             <Label
                 FontSize="{Binding FontSize, Mode=OneWay}"
                 HorizontalTextAlignment="Center"
                 Style="{Binding DaysLabelStyle, Mode=OneWay}"
                 Text="{Binding Date.Day, Mode=OneWay}"
                 TextColor="{Binding TextColor, Mode=OneWay}" />
-            <StackLayout Orientation="Horizontal">
+            <StackLayout Orientation="Horizontal" HeightRequest="8">
                 <Border
                     Padding="0"
                     BackgroundColor="{Binding EventColor, Mode=OneWay}"

--- a/src/Plugin.Maui.Calendar/Shared/Controls/DayView.xaml
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/DayView.xaml
@@ -27,14 +27,14 @@
         Stroke="{Binding OutlineColor, Mode=OneWay}"
         StrokeShape="{Binding DayViewCornerRadius, Converter={StaticResource StrokeShapeConverter}, Mode=OneWay}"
         WidthRequest="{Binding DayViewSize, Mode=OneWay}">
-            <Border.GestureRecognizers>
-                <TapGestureRecognizer Tapped="OnTapped" />
-            </Border.GestureRecognizers>
         </Border>
         <FlexLayout
             AlignItems="Center"
             Direction="{Binding EventLayoutDirection}"
             JustifyContent="Center">
+            <FlexLayout.GestureRecognizers>
+                <TapGestureRecognizer Tapped="OnTapped" />
+            </FlexLayout.GestureRecognizers>
             <Grid HeightRequest="4"/>
             <Label
                 FontSize="{Binding FontSize, Mode=OneWay}"

--- a/src/Plugin.Maui.Calendar/Shared/Controls/MonthDaysView.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/MonthDaysView.cs
@@ -1157,30 +1157,41 @@ public partial class MonthDaysView : ContentView
 
     internal void AssignIndicatorColors(ref DayModel dayModel)
     {
+        dayModel.EventIndicatorColor = EventIndicatorColor;
+        dayModel.EventIndicatorSelectedColor = EventIndicatorSelectedColor;
+        dayModel.EventIndicatorTextColor = EventIndicatorTextColor;
+        dayModel.EventIndicatorSelectedTextColor = EventIndicatorSelectedTextColor;
         if (
             Events.TryGetValue(dayModel.Date, out var dayEventCollection)
-            && dayEventCollection is IPersonalizableDayEvent personalizableDay
         )
         {
-            dayModel.EventIndicatorColor =
-                personalizableDay?.EventIndicatorColor ?? EventIndicatorColor;
-            dayModel.EventIndicatorSelectedColor =
-                personalizableDay?.EventIndicatorSelectedColor
-                ?? personalizableDay?.EventIndicatorColor
-                ?? EventIndicatorSelectedColor;
-            dayModel.EventIndicatorTextColor =
-                personalizableDay?.EventIndicatorTextColor ?? EventIndicatorTextColor;
-            dayModel.EventIndicatorSelectedTextColor =
-                personalizableDay?.EventIndicatorSelectedTextColor
-                ?? personalizableDay?.EventIndicatorTextColor
-                ?? EventIndicatorSelectedTextColor;
+            if (dayEventCollection is IPersonalizableDayEvent personalizableDay)
+            {
+                dayModel.EventIndicatorColor =
+                    personalizableDay?.EventIndicatorColor ?? EventIndicatorColor;
+                dayModel.EventIndicatorSelectedColor =
+                    personalizableDay?.EventIndicatorSelectedColor
+                 ?? personalizableDay?.EventIndicatorColor
+                 ?? EventIndicatorSelectedColor;
+                dayModel.EventIndicatorTextColor =
+                    personalizableDay?.EventIndicatorTextColor ?? EventIndicatorTextColor;
+                dayModel.EventIndicatorSelectedTextColor =
+                    personalizableDay?.EventIndicatorSelectedTextColor
+                 ?? personalizableDay?.EventIndicatorTextColor
+                 ?? EventIndicatorSelectedTextColor;
+            }
+            if (dayEventCollection is IMultiEventDay multiEventDay)
+            {
+                dayModel.EventColors = multiEventDay.Colors?.ToArray() ?? new Color[0];
+            }
+            else
+            {
+                dayModel.EventColors = new Color[0];
+            }
         }
         else
         {
-            dayModel.EventIndicatorColor = EventIndicatorColor;
-            dayModel.EventIndicatorSelectedColor = EventIndicatorSelectedColor;
-            dayModel.EventIndicatorTextColor = EventIndicatorTextColor;
-            dayModel.EventIndicatorSelectedTextColor = EventIndicatorSelectedTextColor;
+            dayModel.EventColors = new Color[0];
         }
     }
 

--- a/src/Plugin.Maui.Calendar/Shared/Interfaces/IMultiEventDay.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Interfaces/IMultiEventDay.cs
@@ -1,0 +1,6 @@
+﻿namespace Plugin.Maui.Calendar.Interfaces;
+
+public interface IMultiEventDay
+{
+    IReadOnlyList<Color> Colors { get; }
+}

--- a/src/Plugin.Maui.Calendar/Shared/Models/DayModel.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Models/DayModel.cs
@@ -95,6 +95,10 @@ internal partial class DayModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(
         nameof(IsEventDotVisible),
+        nameof(IsSecondEventDotVisible),
+        nameof(IsThirdEventDotVisible),
+        nameof(IsFourthEventDotVisible),
+        nameof(IsFifthEventDotVisible),
         nameof(BackgroundEventIndicator),
         nameof(BackgroundColor)
     )]
@@ -107,6 +111,19 @@ internal partial class DayModel : ObservableObject
         nameof(BackgroundFullEventColor)
     )]
     Color eventIndicatorColor = Color.FromArgb("#FF4081");
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(
+        nameof(IsSecondEventDotVisible),
+        nameof(IsThirdEventDotVisible),
+        nameof(IsFourthEventDotVisible),
+        nameof(IsFifthEventDotVisible),
+        nameof(SecondEventColor),
+        nameof(ThirdEventColor),
+        nameof(FourthEventColor),
+        nameof(FifthEventColor)
+    )]
+    private IReadOnlyList<Color> eventColors;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(
@@ -144,6 +161,11 @@ internal partial class DayModel : ObservableObject
             || EventIndicatorType == EventIndicatorType.TopDot
         );
 
+    public bool IsSecondEventDotVisible => EventColors?.Count>=2 && (EventIndicatorType == EventIndicatorType.BottomDot || EventIndicatorType == EventIndicatorType.TopDot);
+    public bool IsThirdEventDotVisible => EventColors?.Count>=3 && (EventIndicatorType == EventIndicatorType.BottomDot || EventIndicatorType == EventIndicatorType.TopDot);
+    public bool IsFourthEventDotVisible => EventColors?.Count>=4 && (EventIndicatorType == EventIndicatorType.BottomDot || EventIndicatorType == EventIndicatorType.TopDot);
+    public bool IsFifthEventDotVisible => EventColors?.Count>=5 && (EventIndicatorType == EventIndicatorType.BottomDot || EventIndicatorType == EventIndicatorType.TopDot);
+
     public FlexDirection EventLayoutDirection =>
         (HasEvents && EventIndicatorType == EventIndicatorType.TopDot)
             ? FlexDirection.ColumnReverse
@@ -158,6 +180,11 @@ internal partial class DayModel : ObservableObject
             : Colors.Transparent;
 
     public Color EventColor => IsSelected ? EventIndicatorSelectedColor : EventIndicatorColor;
+
+    public Color SecondEventColor => EventColors != null && EventColors.Count >= 2 ? EventColors[ 1 ] : Colors.Transparent;
+    public Color ThirdEventColor => EventColors != null && EventColors.Count >= 3 ? EventColors[ 2 ] : Colors.Transparent;
+    public Color FourthEventColor => EventColors != null && EventColors.Count >= 4 ? EventColors[ 3 ] : Colors.Transparent;
+    public Color FifthEventColor => EventColors != null && EventColors.Count >= 5 ? EventColors[ 4 ] : Colors.Transparent;
 
     public Color OutlineColor => IsToday && !IsSelected ? TodayOutlineColor : Colors.Transparent;
 


### PR DESCRIPTION
added `IMultiEventDay` that allows a `DayEventCollection` to specify up to five individual colors for events that will be displayed as multiple dots on that day

![grafik](https://github.com/user-attachments/assets/f7e13056-99a5-4613-8b05-85fe11a15c29)
