### PR TITLE
UI styling adjustments/features

### DIFF
--- a/samples/SampleApp/Views/MultiSelectionPage.xaml
+++ b/samples/SampleApp/Views/MultiSelectionPage.xaml
@@ -18,7 +18,7 @@
             <Style x:Key="MyDaysLabelStyle" TargetType="Label">
                 <Setter Property="HorizontalTextAlignment" Value="Center" />
                 <Setter Property="TextColor" Value="Black" />
-                <Setter Property="FontSize" Value="Medium" />
+                <Setter Property="FontSize" Value="16" />
                 <Setter Property="LineBreakMode" Value="WordWrap" />
                 <Setter Property="VerticalTextAlignment" Value="Center" />
                 <Setter Property="Margin" Value="5,2" />

--- a/samples/SampleApp/Views/SimplePage.xaml
+++ b/samples/SampleApp/Views/SimplePage.xaml
@@ -52,6 +52,7 @@
         EventIndicatorTextColor="{toolkit:AppThemeResource DeselectedDayLabelTextColor}"
         Events="{Binding Events}"
         EventsScrollViewVisible="True"
+        OtherMonthWeekIsVisible="False"
         FirstDayOfWeek="Monday"
         HorizontalOptions="Fill"
         MaximumDate="{Binding MaximumDate}"

--- a/samples/SampleApp/Views/SimplePage.xaml
+++ b/samples/SampleApp/Views/SimplePage.xaml
@@ -44,6 +44,7 @@
         Padding="10,0"
         AllowDeselecting="False"
         Day="{Binding Day}"
+        DayViewBorderMargin="6,4,6,8"
         DaysLabelStyle="{StaticResource MyDaysLabelStyle}"
         DaysTitleLabelStyle="{StaticResource MyDaysTitleLabelStyle}"
         DeselectedDayTextColor="{toolkit:AppThemeResource DeselectedDayLabelTextColor}"

--- a/samples/SampleApp/Views/SimplePage.xaml
+++ b/samples/SampleApp/Views/SimplePage.xaml
@@ -17,7 +17,7 @@
             <Style x:Key="MyDaysLabelStyle" TargetType="Label">
                 <Setter Property="HorizontalTextAlignment" Value="Center" />
                 <Setter Property="TextColor" Value="Black" />
-                <Setter Property="FontSize" Value="Medium" />
+                <Setter Property="FontSize" Value="16" />
                 <Setter Property="LineBreakMode" Value="WordWrap" />
                 <Setter Property="VerticalTextAlignment" Value="Center" />
                 <Setter Property="Margin" Value="5,2" />

--- a/src/Plugin.Maui.Calendar/Shared/Controls/Calendar.xaml.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/Calendar.xaml.cs
@@ -741,6 +741,24 @@ public partial class Calendar : ContentView, IDisposable
 		set => SetValue(DayViewSizeProperty, value);
 	}
 
+	/// <summary>
+	/// Bindable property for DayViewBorderMargin
+	/// </summary>
+	public static readonly BindableProperty DayViewBorderMarginProperty = BindableProperty.Create(
+		nameof(DayViewBorderMargin),
+		typeof(Thickness),
+		typeof(Calendar),
+		default(Thickness)
+	);
+
+	/// <summary>
+	/// Specifies the margin of dayview border
+	/// </summary>
+	public Thickness DayViewBorderMargin
+	{
+		get => (Thickness)GetValue(DayViewBorderMarginProperty);
+		set => SetValue(DayViewBorderMarginProperty, value);
+	}	
 
 	/// <summary>
 	/// Bindable property for DayViewCornerRadius
@@ -2116,6 +2134,7 @@ public partial class Calendar : ContentView, IDisposable
 			dayModel.DayTappedCommand = DayTappedCommand;
 			dayModel.EventIndicatorType = EventIndicatorType;
 			dayModel.DayViewSize = DayViewSize;
+			dayModel.DayViewBorderMargin = DayViewBorderMargin;
 			dayModel.DayViewCornerRadius = DayViewCornerRadius;
 			dayModel.DaysLabelStyle = DaysLabelStyle;
 			dayModel.IsThisMonth =

--- a/src/Plugin.Maui.Calendar/Shared/Controls/Calendar.xaml.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/Calendar.xaml.cs
@@ -425,6 +425,35 @@ public partial class Calendar : ContentView, IDisposable
 
 
 	/// <summary>
+	/// Bindable property for OtherMonthWeekIsVisible
+	/// </summary>
+	public static readonly BindableProperty OtherMonthWeekIsVisibleProperty = BindableProperty.Create(
+		nameof(OtherMonthWeekIsVisible),
+		typeof(bool),
+		typeof(Calendar),
+		true,
+		propertyChanged: OnOtherMonthWeekIsVisibleChanged
+	);
+
+	/// <summary>
+	/// Specifies whether the weeks belonging to a month other than the selected one will be shown
+	/// </summary>
+	public bool OtherMonthWeekIsVisible
+	{
+		get => (bool)GetValue(OtherMonthWeekIsVisibleProperty);
+		set => SetValue(OtherMonthWeekIsVisibleProperty, value);
+	}
+
+	static void OnOtherMonthWeekIsVisibleChanged(BindableObject bindable, object oldValue, object newValue)
+	{
+		if (bindable is Calendar calendar)
+		{
+			calendar.UpdateDays();
+		}
+	}
+
+
+	/// <summary>
 	/// Binding property for CalendarSectionShown
 	/// </summary>
 	public static readonly BindableProperty CalendarSectionShownProperty = BindableProperty.Create(
@@ -2118,6 +2147,7 @@ public partial class Calendar : ContentView, IDisposable
 	DateTime firstDate = DateTime.MinValue;
 	void UpdateDays(bool forceUpdate = false)
 	{
+		int lastDayOfMonth = 0;
 		if (!forceUpdate && firstDate == CurrentViewLayoutEngine.GetFirstDate(ShownDate))
 		{
 			return;
@@ -2130,6 +2160,10 @@ public partial class Calendar : ContentView, IDisposable
 			var currentDate = firstDate.AddDays(addDays++);
 			var dayModel = dayView.BindingContext as DayModel;
 
+			if (currentDate.Month == ShownDate.Month)
+				lastDayOfMonth = addDays;
+			bool currentMonthOnLine = (lastDayOfMonth == 0 || (addDays-1) / 7 == (lastDayOfMonth-1) / 7 );
+				
 			dayModel.Date = currentDate.Date;
 			dayModel.DayTappedCommand = DayTappedCommand;
 			dayModel.EventIndicatorType = EventIndicatorType;
@@ -2141,6 +2175,8 @@ public partial class Calendar : ContentView, IDisposable
 				(CalendarLayout != WeekLayout.Month) || currentDate.Month == ShownDate.Month;
 			dayModel.OtherMonthIsVisible =
 				(CalendarLayout != WeekLayout.Month) || OtherMonthDayIsVisible;
+			dayModel.OtherMonthWeekIsVisible =
+				(CalendarLayout != WeekLayout.Month) || OtherMonthWeekIsVisible || (OtherMonthDayIsVisible && currentMonthOnLine);
 			dayModel.HasEvents = Events.ContainsKey(currentDate);
 			dayModel.IsDisabled =
 				currentDate < MinimumDate

--- a/src/Plugin.Maui.Calendar/Shared/Controls/DayView.xaml
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/DayView.xaml
@@ -21,12 +21,14 @@
         WidthRequest="{Binding DayViewSize, Mode=OneWay}">
         <Border
             Padding="0"
+            Margin="{Binding DayViewBorderMargin, Mode=OneWay}"
             BackgroundColor="{Binding BackgroundColor, Mode=OneWay}"
-            HeightRequest="{Binding DayViewSize, Mode=OneWay}"
-            HorizontalOptions="Center"
+            MaximumHeightRequest="{Binding DayViewSize, Mode=OneWay}"
+            HorizontalOptions="Fill"
             Stroke="{Binding OutlineColor, Mode=OneWay}"
             StrokeShape="{Binding DayViewCornerRadius, Converter={StaticResource StrokeShapeConverter}, Mode=OneWay}"
-            WidthRequest="{Binding DayViewSize, Mode=OneWay}"/>
+            MaximumWidthRequest="{Binding DayViewSize, Mode=OneWay}"
+            VerticalOptions="Fill"/>
         <FlexLayout
             AlignItems="Center"
             Direction="{Binding EventLayoutDirection}"

--- a/src/Plugin.Maui.Calendar/Shared/Controls/DayView.xaml
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/DayView.xaml
@@ -7,6 +7,7 @@
     xmlns:models="clr-namespace:Plugin.Maui.Calendar.Models"
     x:Name="dayView"
     x:DataType="models:DayModel"
+    IsVisible="{Binding IsControlVisible, Mode=OneWay}"
     BackgroundColor="{Binding BackgroundFullEventColor}">
     <ContentView.Resources>
         <ResourceDictionary>

--- a/src/Plugin.Maui.Calendar/Shared/Models/DayModel.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Models/DayModel.cs
@@ -39,7 +39,7 @@ sealed partial class DayModel : ObservableObject
 	bool hasEvents;
 
 	[ObservableProperty]
-	[NotifyPropertyChangedFor(nameof(TextColor), nameof(IsVisible))]
+	[NotifyPropertyChangedFor(nameof(TextColor), nameof(IsVisible), nameof(IsControlVisible))]
 	bool isThisMonth;
 
 	[ObservableProperty]
@@ -57,6 +57,10 @@ sealed partial class DayModel : ObservableObject
 	[ObservableProperty]
 	[NotifyPropertyChangedFor(nameof(IsVisible))]
 	bool otherMonthIsVisible;
+
+	[ObservableProperty]
+	[NotifyPropertyChangedFor(nameof(IsControlVisible))]
+	bool otherMonthWeekIsVisible;
 
 	[ObservableProperty]
 	[NotifyPropertyChangedFor(nameof(TextColor))]
@@ -199,6 +203,8 @@ sealed partial class DayModel : ObservableObject
 
 	public bool IsVisible => IsThisMonth || OtherMonthIsVisible;
 
+	public bool IsControlVisible => IsThisMonth || OtherMonthWeekIsVisible;
+	
 	bool IsToday => Date.Date == DateTime.Today;
 
 	public bool IsWeekend => (Date.DayOfWeek == DayOfWeek.Saturday || Date.DayOfWeek == DayOfWeek.Sunday) && WeekendDayColor != Colors.Transparent;

--- a/src/Plugin.Maui.Calendar/Shared/Models/DayModel.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Models/DayModel.cs
@@ -15,6 +15,9 @@ sealed partial class DayModel : ObservableObject
 	DateTime date;
 
 	[ObservableProperty]
+	Thickness dayViewBorderMargin = new(0, 0, 0, 0);
+	
+	[ObservableProperty]
 	double dayViewSize;
 
 	[ObservableProperty]


### PR DESCRIPTION
Hi

coundn't "help myself" and started implementing some additional styling features.

**DayViewBorderMargin** is optional (default 0,0,0,0)
Allows to better control the border marking of the individual days. Please have a look at SimplePage.xaml to see how I adjusted the circle to enclose the "date" - but not the individual indicators.

Please note - as the FontSize "Medium" may vary by platform I also adjusted the style for the days in both SimplePage.xaml and MultiSelectionPage.xaml to be "16" instead of "Medium" - otherwise it's almost impossible to predict the size of anything across platforms.

**OtherMonthWeekIsVisible** is also optional (default true)
Allows the ability to hide whole weeks not in current month *and* adjust the height dynamically.
Please look at SimplePage.xaml to see how it's working.
An implementation of the functionality requested in [this](https://github.com/yurkinh/Plugin.Maui.Calendar/issues/173)


/René