### PR TITLE
Adds AutoChangeMonthOnDayTap property

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ V2.0.0
 * Updated samples
 * Added native digits support (added **UseNativeDigits** Property)
 * Added **OtherMonthWeekIsVisible** and **DayViewBorderMargin** properties
+* Added **AutoChangeMonthOnDayTap** property — allows automatically switching the displayed month when user taps on a day from another month (disabled by default)
+
 
 ### Breaking  Changes
 
@@ -295,6 +297,7 @@ FirstDayOfWeek="Monday"
 UseNativeDigits="True"
 OtherMonthWeekIsVisible="False"
 DayViewBorderMargin
+AutoChangeMonthOnDayTap="True"
 ```
 
 #### Calendar Layout customizations

--- a/src/Plugin.Maui.Calendar/Shared/Controls/Calendar.xaml.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/Calendar.xaml.cs
@@ -2214,9 +2214,8 @@ public partial class Calendar : ContentView, IDisposable
 		{
 			if (value.Month != ShownDate.Month || value.Year != ShownDate.Year)
 			{
-				ShownDate = value;
-
 				var oldMonth = new DateOnly(ShownDate.Year, ShownDate.Month, 1);
+				ShownDate = value;
 				var newMonth = new DateOnly(value.Year, value.Month, 1);
 
 				MonthChanged?.Invoke(this, new MonthChangedEventArgs(oldMonth, newMonth));

--- a/src/Plugin.Maui.Calendar/Shared/Controls/Calendar.xaml.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/Calendar.xaml.cs
@@ -2215,8 +2215,9 @@ public partial class Calendar : ContentView, IDisposable
 			if (value.Month != ShownDate.Month || value.Year != ShownDate.Year)
 			{
 				var oldMonth = new DateOnly(ShownDate.Year, ShownDate.Month, 1);
-				ShownDate = value;
 				var newMonth = new DateOnly(value.Year, value.Month, 1);
+				
+				ShownDate = value;
 
 				MonthChanged?.Invoke(this, new MonthChangedEventArgs(oldMonth, newMonth));
 


### PR DESCRIPTION
Introduces a new `AutoChangeMonthOnDayTap` property to the calendar control.

This property allows the calendar to automatically switch to the month of a day selected by the user, even if that day belongs to a different month. This enhances user experience by simplifying navigation across months.

Fixes #200 