### PR TITLE
Specifies data type for event command binding

### DIFF
--- a/samples/SampleApp/Views/AdvancedPage.xaml
+++ b/samples/SampleApp/Views/AdvancedPage.xaml
@@ -101,7 +101,7 @@
 
         <plugin:Calendar.EventTemplate>
             <DataTemplate x:DataType="model:AdvancedEventModel">
-                <controls:CalenderEvent CalenderEventCommand="{Binding EventSelectedCommand, Source={x:Reference advancedCalendarPage}}" />
+                <controls:CalenderEvent CalenderEventCommand="{Binding EventSelectedCommand, Source={x:Reference advancedCalendarPage}, x:DataType=local:AdvancedPageViewModel}" />
             </DataTemplate>
         </plugin:Calendar.EventTemplate>
         <plugin:Calendar.EmptyTemplate>


### PR DESCRIPTION
fixed:  Binding: Property "EventSelectedCommand" not found on "SampleApp.Model.AdvancedEventModel"
