### PR TITLE
Added weekend day background color property

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,20 @@ TodayTextColor="Yellow"
 OtherMonthSelectedDayColor="HotPink"
 ```
 
+##### Weekend column background
+
+`WeekendDayBackgroundColor` fills the background of each weekend (Saturday/Sunday) day cell.
+The day-of-week title row is left uncovered, and vertically-consecutive weekend days touch
+with no gap while remaining individual rounded boxes. It is opt-in and defaults to
+`Transparent`, so existing calendars are unaffected. The weekend columns are derived from
+`FirstDayOfWeek`. Use `WeekendDayBackgroundCornerRadius` to round each box.
+
+```xml
+<controls:Calendar
+    WeekendDayBackgroundColor="#EEF0F4"
+    WeekendDayBackgroundCornerRadius="12"/>
+```
+
 #### Available Styles
 | Style Key                       | Based On (`DefaultStyles`)                           |
 | ------------------------------- | ---------------------------------------------------- |

--- a/samples/SampleApp/AppShell.xaml.cs
+++ b/samples/SampleApp/AppShell.xaml.cs
@@ -10,6 +10,7 @@ public partial class AppShell : Shell
 
 		Routing.RegisterRoute(nameof(MainPage), typeof(MainPage));
 		Routing.RegisterRoute(nameof(WeekendCalendarPage), typeof(WeekendCalendarPage));
+		Routing.RegisterRoute(nameof(WeekendFilledCalendarPage), typeof(WeekendFilledCalendarPage));
 		Routing.RegisterRoute(nameof(MultiSelectionPage), typeof(MultiSelectionPage));
 		Routing.RegisterRoute(nameof(AdvancedPage), typeof(AdvancedPage));
 		Routing.RegisterRoute(nameof(RangeSelectionPage), typeof(RangeSelectionPage));

--- a/samples/SampleApp/ViewModels/WeekendFilledCalendarPageViewModel.cs
+++ b/samples/SampleApp/ViewModels/WeekendFilledCalendarPageViewModel.cs
@@ -1,0 +1,76 @@
+using Plugin.Maui.Calendar.Models;
+
+namespace SampleApp.ViewModels;
+
+public partial class WeekendFilledCalendarPageViewModel : BasePageViewModel
+{
+    static readonly Color ShiftColor = Color.FromArgb("#2E9E4A");
+    static readonly Color LeaveColor = Color.FromArgb("#E8941E");
+    static readonly Color SickColor = Color.FromArgb("#C0392B");
+    static readonly Color HolidayColor = Color.FromArgb("#E6B800");
+
+    // Day-of-month -> (title, color), laid out to match the reference design.
+    static readonly (int Day, string Title, Color Color)[] schedule =
+    [
+        (1, "Shift", ShiftColor),
+        (3, "Shift", ShiftColor),
+        (5, "Shift", ShiftColor),
+        (8, "Shift", ShiftColor), (8, "Leave", LeaveColor),
+        (10, "Shift", ShiftColor),
+        (12, "Sick", SickColor),
+        (17, "Shift", ShiftColor),
+        (19, "Holiday", HolidayColor),
+        (22, "Shift", ShiftColor),
+        (23, "Shift", ShiftColor),
+        (24, "Leave", LeaveColor),
+        (25, "Leave", LeaveColor),
+        (26, "Leave", LeaveColor),
+        (29, "Shift", ShiftColor),
+        (30, "Shift", ShiftColor), (30, "Sick", SickColor),
+    ];
+
+    public WeekendFilledCalendarPageViewModel() : base()
+    {
+        Events = BuildEvents();
+    }
+
+    public EventCollection Events { get; }
+
+	[ObservableProperty]
+	public partial DateTime? SelectedDate { get; set; } = DateTime.Today;
+
+	static EventCollection BuildEvents()
+    {
+        var events = new EventCollection();
+        var today = DateTime.Today;
+
+        for (var offset = -1; offset <= 1; offset++)
+        {
+            var monthStart = new DateTime(today.Year, today.Month, 1).AddMonths(offset);
+            var daysInMonth = DateTime.DaysInMonth(monthStart.Year, monthStart.Month);
+
+            var grouped = schedule
+                .Where(s => s.Day <= daysInMonth)
+                .GroupBy(s => monthStart.AddDays(s.Day - 1));
+
+            foreach (var day in grouped)
+            {
+                var dayEvents = new DayEventCollection<EventModel>
+                {
+                    Colors = day.Select(s => s.Color).ToList(),
+                };
+
+                dayEvents.AddRange(day.Select(s => new EventModel
+                {
+                    Name = s.Title,
+                    Description = $"{s.Title} — {day.Key:dd MMM}",
+                    Color = s.Color,
+                }));
+
+                events[day.Key] = dayEvents;
+            }
+        }
+
+        return events;
+    }
+}

--- a/samples/SampleApp/Views/MainPage.xaml
+++ b/samples/SampleApp/Views/MainPage.xaml
@@ -69,6 +69,10 @@
                 Style="{StaticResource ButtonMainPageStyle}"
                 Text="Weekend Calendar" />
             <Button
+                Clicked="WeekendFilledCalendar"
+                Style="{StaticResource ButtonMainPageStyle}"
+                Text="Weekend Filled Calendar" />
+            <Button
                 Clicked="AdvancedCalendar"
                 Style="{StaticResource ButtonMainPageStyle}"
                 Text="Advanced Event Calendar" />

--- a/samples/SampleApp/Views/MainPage.xaml.cs
+++ b/samples/SampleApp/Views/MainPage.xaml.cs
@@ -25,6 +25,10 @@ public partial class MainPage : ContentPage
         await Shell.Current.GoToAsync(nameof(WeekendCalendarPage));
 
 
+    async void WeekendFilledCalendar(object sender, EventArgs e) =>
+        await Shell.Current.GoToAsync(nameof(WeekendFilledCalendarPage));
+
+
     async void MultiSelectionCalendar(object sender, EventArgs e) =>
         await Shell.Current.GoToAsync(nameof(MultiSelectionPage));
 

--- a/samples/SampleApp/Views/WeekendFilledCalendarPage.xaml
+++ b/samples/SampleApp/Views/WeekendFilledCalendarPage.xaml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="SampleApp.Views.WeekendFilledCalendarPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:SampleApp.ViewModels"
+    xmlns:plugin="clr-namespace:Plugin.Maui.Calendar.Controls;assembly=Plugin.Maui.Calendar"
+    xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    x:Name="weekendFilledCalendarPage"
+    Title="Weekend Filled Calendar"
+    x:DataType="local:WeekendFilledCalendarPageViewModel"
+    BackgroundColor="{toolkit:AppThemeResource BackgroundColor}"
+    Shell.TabBarIsVisible="False">
+
+    <ContentPage.BindingContext>
+        <local:WeekendFilledCalendarPageViewModel />
+    </ContentPage.BindingContext>
+
+    <ScrollView>
+        <VerticalStackLayout Padding="0,8" Spacing="0">
+
+            <!--  Calendar / Schedule segment  -->
+            <Border
+                Margin="16,8"
+                Padding="4"
+                BackgroundColor="#EEF0F4"
+                Stroke="Transparent"
+                StrokeShape="RoundRectangle 12">
+                <Grid ColumnDefinitions="*,*">
+                    <Border
+                        Grid.Column="0"
+                        Padding="0,10"
+                        BackgroundColor="#1F2A4D"
+                        Stroke="Transparent"
+                        StrokeShape="RoundRectangle 9">
+                        <Label
+                            FontAttributes="Bold"
+                            HorizontalOptions="Center"
+                            Text="Calendar"
+                            TextColor="White" />
+                    </Border>
+                    <Label
+                        Grid.Column="1"
+                        FontAttributes="Bold"
+                        HorizontalOptions="Center"
+                        Text="Schedule"
+                        TextColor="#6B7280"
+                        VerticalOptions="Center" />
+                </Grid>
+            </Border>
+
+            <plugin:Calendar
+                x:Name="calendar"
+                Margin="8,4"
+                DayViewCornerRadius="5"
+                DaysTitleLabelFirstUpperRestLower="True"
+                EventIndicatorType="BottomDot"
+                Events="{Binding Events}"
+                EventsScrollViewVisible="False"
+                FooterSectionVisible="False"
+                SelectedDate="{Binding SelectedDate}"
+                SelectedDayBackgroundColor="Transparent"
+                SelectedDayTextColor="#1F2A4D"
+                TodayOutlineColor="#1F2A4D"
+                TodayTextColor="#1F2A4D"
+                WeekendDayBackgroundColor="#EEF0F4">
+
+                <!--  Custom header (1:1 with design): ‹ June 2026 ›  -->
+                <plugin:Calendar.HeaderSectionTemplate>
+                    <DataTemplate>
+                        <Grid
+                            Padding="8,6,8,10"
+                            ColumnDefinitions="44,*,44"
+                            x:DataType="plugin:Calendar">
+                            <Button
+                                Grid.Column="0"
+                                Padding="0"
+                                BackgroundColor="Transparent"
+                                BorderWidth="0"
+                                Command="{Binding PrevLayoutUnitCommand}"
+                                FontSize="26"
+                                Text="‹"
+                                TextColor="#1F2A4D" />
+                            <HorizontalStackLayout
+                                Grid.Column="1"
+                                HorizontalOptions="Center"
+                                Spacing="6"
+                                VerticalOptions="Center">
+                                <Label
+                                    FontAttributes="Bold"
+                                    FontSize="18"
+                                    Text="{Binding LayoutUnitText}"
+                                    TextColor="#1F2A4D"
+                                    VerticalOptions="Center" />
+                                <Label
+                                    FontAttributes="Bold"
+                                    FontSize="18"
+                                    Text="{Binding LocalizedYear}"
+                                    TextColor="#1F2A4D"
+                                    VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                            <Button
+                                Grid.Column="2"
+                                Padding="0"
+                                BackgroundColor="Transparent"
+                                BorderWidth="0"
+                                Command="{Binding NextLayoutUnitCommand}"
+                                FontSize="26"
+                                Text="›"
+                                TextColor="#1F2A4D" />
+                        </Grid>
+                    </DataTemplate>
+                </plugin:Calendar.HeaderSectionTemplate>
+
+            </plugin:Calendar>
+
+
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/samples/SampleApp/Views/WeekendFilledCalendarPage.xaml
+++ b/samples/SampleApp/Views/WeekendFilledCalendarPage.xaml
@@ -65,7 +65,6 @@
                 TodayTextColor="#1F2A4D"
                 WeekendDayBackgroundColor="#EEF0F4">
 
-                <!--  Custom header (1:1 with design): ‹ June 2026 ›  -->
                 <plugin:Calendar.HeaderSectionTemplate>
                     <DataTemplate>
                         <Grid

--- a/samples/SampleApp/Views/WeekendFilledCalendarPage.xaml.cs
+++ b/samples/SampleApp/Views/WeekendFilledCalendarPage.xaml.cs
@@ -1,0 +1,11 @@
+namespace SampleApp.Views;
+
+
+public partial class WeekendFilledCalendarPage : ContentPage
+{
+    public WeekendFilledCalendarPage()
+    {
+        InitializeComponent();
+
+    }
+}

--- a/src/Plugin.Maui.Calendar/Plugin.Maui.Calendar.csproj
+++ b/src/Plugin.Maui.Calendar/Plugin.Maui.Calendar.csproj
@@ -9,12 +9,12 @@
 		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     
-    <!-- Enable Source Generators for XAML in .NET 10 -->
-    <MauiXamlInflator>SourceGen</MauiXamlInflator>
-    <!--  <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles> -->
+		<!-- Enable Source Generators for XAML in .NET 10 -->
+		<MauiXamlInflator>SourceGen</MauiXamlInflator>
+		<!--  <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles> -->
     
 		<!-- Enable trimming and AOT analyzers on all platforms -->
 		<!-- <IsAotCompatible>true</IsAotCompatible>

--- a/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.ColorBindableProperties.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.ColorBindableProperties.cs
@@ -58,4 +58,60 @@ public partial class Calendar : ContentView, IDisposable
 			calendar.UpdateDaysColors();
 		}
 	}
+
+
+	/// <summary>
+	/// Bindable property for WeekendDayBackgroundColor
+	/// </summary>
+	public static readonly BindableProperty WeekendDayBackgroundColorProperty = BindableProperty.Create(
+		nameof(WeekendDayBackgroundColor),
+		typeof(Color),
+		typeof(Calendar),
+		Colors.Transparent,
+		propertyChanged: OnWeekendDayBackgroundChanged
+	);
+
+	/// <summary>
+	/// Fills the background of each weekend (Saturday/Sunday) day cell. The day-of-week title
+	/// row is left uncovered, and vertically-consecutive weekend days touch with no gap while
+	/// remaining individual rounded boxes (see <see cref="WeekendDayBackgroundCornerRadius"/>).
+	/// Defaults to <see cref="Colors.Transparent"/>, which keeps the calendar's original
+	/// appearance so existing layouts are unaffected. The weekend columns are derived from
+	/// <see cref="FirstDayOfWeek"/>.
+	/// </summary>
+	public Color WeekendDayBackgroundColor
+	{
+		get => (Color)GetValue(WeekendDayBackgroundColorProperty);
+		set => SetValue(WeekendDayBackgroundColorProperty, value);
+	}
+
+
+	/// <summary>
+	/// Bindable property for WeekendDayBackgroundCornerRadius
+	/// </summary>
+	public static readonly BindableProperty WeekendDayBackgroundCornerRadiusProperty = BindableProperty.Create(
+		nameof(WeekendDayBackgroundCornerRadius),
+		typeof(float),
+		typeof(Calendar),
+		0f,
+		propertyChanged: OnWeekendDayBackgroundChanged
+	);
+
+	/// <summary>
+	/// Corner radius applied to the <see cref="WeekendDayBackgroundColor"/> band. Defaults
+	/// to <c>0</c> (square corners). Has no visual effect while the band is transparent.
+	/// </summary>
+	public float WeekendDayBackgroundCornerRadius
+	{
+		get => (float)GetValue(WeekendDayBackgroundCornerRadiusProperty);
+		set => SetValue(WeekendDayBackgroundCornerRadiusProperty, value);
+	}
+
+	static void OnWeekendDayBackgroundChanged(BindableObject bindable, object oldValue, object newValue)
+	{
+		if (bindable is Calendar calendar)
+		{
+			calendar.UpdateWeekendBackground();
+		}
+	}
 }

--- a/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.Othermethods.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.Othermethods.cs
@@ -174,6 +174,11 @@ public partial class Calendar : ContentView, IDisposable
 		UpdateDayGlobalProperties();
 		UpdateDayTitles();
 		UpdateDays();
+
+		// (Re)create the weekend background boxes for the freshly built grid — but only when
+		// WeekendDayBackgroundColor is set. The grid was just cleared, so any boxes from the
+		// previous layout are already detached; RemoveWeekendBands clears the stale cache.
+		UpdateWeekendBackground();
 	}
 
 	internal void AssignIndicatorColors(ref DayModel dayModel)

--- a/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.PrivateFields.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.PrivateFields.cs
@@ -26,6 +26,11 @@ public partial class Calendar : ContentView, IDisposable
 	// RenderLayout so UpdateDayTitles can iterate them directly.
 	Label[] dayTitleLabels;
 
+	// Weekend-day background boxes, created lazily by UpdateWeekendBackground only while
+	// WeekendDayBackgroundColor is set to a visible colour. Null when the feature is unused
+	// (the default), so nothing extra is added to the visual tree.
+	Border[] weekendBackgroundBands;
+
 	// Item 16: guard flag set during construction so that bindable-property callbacks
 	// that fire before the control is fully initialised skip expensive render passes.
 	// A single consolidated render executes at the end of the constructor.

--- a/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.Updatemethods.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.Updatemethods.cs
@@ -1,4 +1,5 @@
-﻿using Plugin.Maui.Calendar.Enums;
+﻿using Microsoft.Maui.Controls.Shapes;
+using Plugin.Maui.Calendar.Enums;
 using Plugin.Maui.Calendar.Models;
 using Plugin.Maui.Calendar.Shared.Extensions;
 using System.Collections.ObjectModel;
@@ -263,6 +264,104 @@ public partial class Calendar : ContentView, IDisposable
 	/// method for propagating all global properties to DayModels.
 	/// </summary>
 	void UpdateDaysColors() => UpdateDayGlobalProperties();
+
+	/// <summary>
+	/// Synchronises the weekend-day background boxes with <see cref="WeekendDayBackgroundColor"/>
+	/// and <see cref="WeekendDayBackgroundCornerRadius"/>. The boxes are created lazily and only
+	/// while a visible (non-transparent) colour is set, so nothing is added to the visual tree
+	/// when the feature is unused (the default). Called once per layout regeneration and
+	/// whenever either property changes.
+	/// </summary>
+	internal void UpdateWeekendBackground()
+	{
+		// Start from a clean slate so a colour change can never leave stale boxes behind; they
+		// are rebuilt below only when a visible colour is set.
+		RemoveWeekendBands();
+
+		if (WeekendDayBackgroundColor is not { Alpha: > 0 })
+		{
+			return;
+		}
+
+		weekendBackgroundBands = CreateWeekendBands();
+
+		var cornerRadius = new CornerRadius(WeekendDayBackgroundCornerRadius);
+		foreach (var band in weekendBackgroundBands)
+		{
+			band.BackgroundColor = WeekendDayBackgroundColor;
+			band.StrokeShape = new RoundRectangle { CornerRadius = cornerRadius };
+		}
+	}
+
+	/// <summary>
+	/// Creates one input-transparent <see cref="Border"/> behind every weekend day cell (week
+	/// rows only, so the day-of-week title row stays uncovered) and inserts them at the front
+	/// of <c>daysControl</c> so they render behind the day cells. Each box bleeds half the row
+	/// spacing above and below (a negative vertical margin) so vertically-consecutive weekend
+	/// days touch with no gap. Weekend columns are derived from <see cref="FirstDayOfWeek"/>.
+	/// </summary>
+	Border[] CreateWeekendBands()
+	{
+		const int daysInWeek = 7;
+
+		int rowCount = daysControl.RowDefinitions.Count;
+		if (rowCount <= 1)
+		{
+			// Grid not built yet (or header only) — nothing to place boxes behind.
+			return [];
+		}
+
+		int numberOfWeeks = rowCount - 1;
+		double verticalBleed = daysControl.RowSpacing / 2d;
+
+		var bands = new List<Border>();
+		for (int col = 0; col < daysInWeek; col++)
+		{
+			if (!ViewLayoutEngines.ViewLayoutBase.IsWeekendColumn(FirstDayOfWeek, col))
+			{
+				continue;
+			}
+
+			for (int week = 1; week <= numberOfWeeks; week++)
+			{
+				var band = new Border
+				{
+					BackgroundColor = Colors.Transparent,
+					Stroke = Colors.Transparent,
+					StrokeThickness = 0,
+					Padding = 0,
+					Margin = new Thickness(0, -verticalBleed, 0, -verticalBleed),
+					InputTransparent = true,
+				};
+				Grid.SetColumn(band, col);
+				Grid.SetRow(band, week);
+
+				// Insert at the front so the box sits behind the titles and day cells.
+				daysControl.Children.Insert(bands.Count, band);
+				bands.Add(band);
+			}
+		}
+
+		return [.. bands];
+	}
+
+	/// <summary>
+	/// Detaches and forgets any weekend background boxes previously added to <c>daysControl</c>.
+	/// </summary>
+	void RemoveWeekendBands()
+	{
+		if (weekendBackgroundBands is null)
+		{
+			return;
+		}
+
+		foreach (var band in weekendBackgroundBands)
+		{
+			daysControl.Children.Remove(band);
+		}
+
+		weekendBackgroundBands = null;
+	}
 
 	/// <summary>
 	/// Returns <see langword="true"/> when <paramref name="currentDate"/> falls outside the

--- a/src/Plugin.Maui.Calendar/Shared/Controls/ViewLayoutEngines/ViewLayoutBase.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/ViewLayoutEngines/ViewLayoutBase.cs
@@ -14,6 +14,18 @@ abstract class ViewLayoutBase(DayOfWeek firstDayOfWeek)
 	}
 
 	/// <summary>
+	/// Returns <see langword="true"/> when the grid column at <paramref name="column"/>
+	/// (0-based, measured from <paramref name="firstDayOfWeek"/>) falls on a Saturday or
+	/// Sunday. Used by <see cref="Calendar.UpdateWeekendBackground"/> to place the weekend
+	/// background boxes on the same columns as the Saturday/Sunday day-of-week titles.
+	/// </summary>
+	internal static bool IsWeekendColumn(DayOfWeek firstDayOfWeek, int column)
+	{
+		int dayNumber = ((int)firstDayOfWeek + column) % numberOfDaysInWeek;
+		return dayNumber == (int)DayOfWeek.Saturday || dayNumber == (int)DayOfWeek.Sunday;
+	}
+
+	/// <summary>
 	/// Populates <paramref name="targetGrid"/> with the day-of-week header row and
 	/// <paramref name="numberOfWeeks"/> × 7 <see cref="DayView"/> cells.
 	/// The caller must clear the grid's Children, RowDefinitions and ColumnDefinitions

--- a/tests/Plugin.Maui.Calendar.Tests/Controls/ViewLayoutEngines/WeekendColumnTests.cs
+++ b/tests/Plugin.Maui.Calendar.Tests/Controls/ViewLayoutEngines/WeekendColumnTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using Plugin.Maui.Calendar.Controls.ViewLayoutEngines;
+using Xunit;
+
+namespace Plugin.Maui.Calendar.Tests.Controls.ViewLayoutEngines;
+
+/// <summary>
+/// Verifies <see cref="ViewLayoutBase.IsWeekendColumn"/>, which decides which grid columns
+/// receive the weekend background band. The mapping must follow <c>FirstDayOfWeek</c> so the
+/// band lines up with the Saturday/Sunday day-of-week titles in every configuration.
+/// </summary>
+public class WeekendColumnTests
+{
+    [Theory]
+    // FirstDayOfWeek = Sunday -> columns: Sun Mon Tue Wed Thu Fri Sat
+    [InlineData(DayOfWeek.Sunday, 0, true)]   // Sun
+    [InlineData(DayOfWeek.Sunday, 1, false)]  // Mon
+    [InlineData(DayOfWeek.Sunday, 5, false)]  // Fri
+    [InlineData(DayOfWeek.Sunday, 6, true)]   // Sat
+    // FirstDayOfWeek = Monday -> columns: Mon Tue Wed Thu Fri Sat Sun
+    [InlineData(DayOfWeek.Monday, 0, false)]  // Mon
+    [InlineData(DayOfWeek.Monday, 4, false)]  // Fri
+    [InlineData(DayOfWeek.Monday, 5, true)]   // Sat
+    [InlineData(DayOfWeek.Monday, 6, true)]   // Sun
+    // FirstDayOfWeek = Saturday -> columns: Sat Sun Mon Tue Wed Thu Fri
+    [InlineData(DayOfWeek.Saturday, 0, true)]  // Sat
+    [InlineData(DayOfWeek.Saturday, 1, true)]  // Sun
+    [InlineData(DayOfWeek.Saturday, 2, false)] // Mon
+    [InlineData(DayOfWeek.Saturday, 6, false)] // Fri
+    public void IsWeekendColumn_MapsColumnsRelativeToFirstDayOfWeek(
+        DayOfWeek firstDayOfWeek, int column, bool expected)
+    {
+        ViewLayoutBase.IsWeekendColumn(firstDayOfWeek, column)
+            .Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(DayOfWeek.Sunday)]
+    [InlineData(DayOfWeek.Monday)]
+    [InlineData(DayOfWeek.Saturday)]
+    public void IsWeekendColumn_AlwaysMarksExactlyTwoWeekendColumnsPerWeek(DayOfWeek firstDayOfWeek)
+    {
+        var weekendColumns = Enumerable.Range(0, 7)
+            .Count(col => ViewLayoutBase.IsWeekendColumn(firstDayOfWeek, col));
+
+        weekendColumns.Should().Be(2,
+            "every week has exactly one Saturday and one Sunday regardless of FirstDayOfWeek");
+    }
+}


### PR DESCRIPTION
**Adds two new bindable properties on Calendar to fill the background of weekend day cells:**
WeekendDayBackgroundColor (Color, default Transparent) — background colour for Saturday/Sunday cells.
WeekendDayBackgroundCornerRadius (float, default 0) — corner radius of each box.
Each weekend day gets its own rounded box; vertically-consecutive weekend days touch with no gap (the grid's row spacing is cancelled with a negative margin), while the day-of-week title row stays uncovered. Weekend columns are derived from FirstDayOfWeek.

**Why**
Requested ability to highlight weekends (e.g. shift/schedule calendars) without restyling each day manually.

**Backward compatibility**
Fully opt-in (Open/Closed). Default is Transparent, and the boxes are only added to the visual tree when a visible colour is set — when unused, nothing changes in layout, rendering, input handling, or DayModel. The boxes are input-transparent and sit behind day cells, so taps, selection, "today", and event indicators are unaffected.