### PR TITLE
fix: stop Calendar emitting List→ObservableCollection binding warning

### DIFF
--- a/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.SelectedDatesBindableProperies.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.SelectedDatesBindableProperies.cs
@@ -26,10 +26,11 @@ public partial class Calendar : ContentView, IDisposable
 		get => (DateTime?)GetValue(SelectedDateProperty);
 		set
 		{
-			SetValue(
-				SelectedDatesProperty,
-				value.HasValue ? new List<DateTime> { value.Value } : null
-			);
+			// Intentionally does NOT assign SelectedDates. Syncing it from
+			// SelectedDate is handled by OnSelectedDateChanged, which applies the
+			// multi-selection guard. Assigning it here would clobber an
+			// in-progress multi-selection with a single date, because this setter
+			// runs inside the SelectedDates setter (SelectedDate = value.First()).
 			SetValue(SelectedDateProperty, value);
 		}
 	}
@@ -47,7 +48,7 @@ public partial class Calendar : ContentView, IDisposable
 			}
 			else
 			{
-				control.SetValue(SelectedDatesProperty, new List<DateTime>());
+				control.SetValue(SelectedDatesProperty, new ObservableCollection<DateTime>());
 			}
 		}
 		else


### PR DESCRIPTION
SelectedDatesProperty is declared as ObservableCollection<DateTime>, but two
code paths assigned a List<DateTime> via SetValue. MAUI cannot convert
List<DateTime> to ObservableCollection<DateTime>, so it logged
"Cannot convert System.Collections.Generic.List`1[System.DateTime] to type
ObservableCollection`1[System.DateTime]" on every date tap in
MultiSelectionCalendar (and on page load when dates are pre-selected).

Fix:
- SelectedDate setter: drop the redundant SetValue(SelectedDatesProperty, ...).
  It was a failing no-op (the conversion never applied) and is unnecessary:
  OnSelectedDateChanged already syncs SelectedDates and honours the
  multi-selection guard. Note: simply retyping it to ObservableCollection
  (as one might expect) would silence the warning but BREAK multi-selection —
  the setter runs inside the SelectedDates setter via SelectedDate = First(),
  so a successful assignment would clobber the in-progress selection down to a
  single date.
- OnSelectedDateChanged clear path: use new ObservableCollection<DateTime>()
  instead of new List<DateTime>() so the clear actually applies and no longer
  warns.

Verified on Mac Catalyst: no binding warning on load or tap; multi-select add
and deselect both work; build is warning-free.

Fixes #257 