### PR TITLE
add OtherMonthSelectedDayTextColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ V2.0.0
 * Added **OtherMonthWeekIsVisible** and **DayViewBorderMargin** properties
 * Added **AutoChangeMonthOnDayTap** property — allows automatically switching the displayed month when user taps on a day from another month (disabled by default)
 * Added **UseAbbreviatedDayNames** property — allows using built-in .NET AbbreviatedDayNames without trimming. When this property is enabled, **DaysTitleMaximumLength** is ignored.
+* Added **OtherMonthSelectedDayTextColor** property — sets the text color of a selected day that belongs to another month. Renamed from **OtherMonthSelectedDayColor** for naming consistency; the old name still works but is now deprecated and will be removed in a future release.
 
 
 ### Breaking  Changes
@@ -273,7 +274,7 @@ SelectedTodayTextColor="Green"
 TodayOutlineColor="Blue"
 TodayFillColor="Silver"
 TodayTextColor="Yellow"
-OtherMonthSelectedDayColor="HotPink"
+OtherMonthSelectedDayTextColor="HotPink"
 ```
 
 ##### Weekend column background

--- a/samples/SampleApp/Views/SimplePage.xaml
+++ b/samples/SampleApp/Views/SimplePage.xaml
@@ -60,7 +60,7 @@
         MinimumDate="{Binding MinimumDate}"
         Month="{Binding Month}"
         MonthChangedCommand="{Binding MonthChangedCommand}"
-        OtherMonthSelectedDayColor="HotPink"
+        OtherMonthSelectedDayTextColor="HotPink"
         OtherMonthWeekIsVisible="False"
         SelectedDate="{Binding SelectedDate}"
         SwipeDetectionDisabled="False"

--- a/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.SelectedDayBindableProperies.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.SelectedDayBindableProperies.cs
@@ -90,8 +90,42 @@ public partial class Calendar : ContentView, IDisposable
 
 
 	/// <summary>
+	/// Bindable property for OtherMonthSelectedDayTextColor
+	/// </summary>
+	public static readonly BindableProperty OtherMonthSelectedDayTextColorProperty = BindableProperty.Create(
+		nameof(OtherMonthSelectedDayTextColor),
+		typeof(Color),
+		typeof(Calendar),
+		Colors.Silver,
+		propertyChanged: OnOtherMonthSelectedDayTextColorChanged
+	);
+
+	/// <summary>
+	/// Specifies the text color of selected days belonging to a month other than the selected one
+	/// </summary>
+	public Color OtherMonthSelectedDayTextColor
+	{
+		get => (Color)GetValue(OtherMonthSelectedDayTextColorProperty);
+		set => SetValue(OtherMonthSelectedDayTextColorProperty, value);
+	}
+
+	static void OnOtherMonthSelectedDayTextColorChanged(BindableObject bindable, object oldValue, object newValue)
+	{
+		if (bindable is Calendar calendar)
+		{
+			// Keep the deprecated alias in sync so existing bindings keep working.
+#pragma warning disable CS0618 // Type or member is obsolete
+			calendar.OtherMonthSelectedDayColor = (Color)newValue;
+#pragma warning restore CS0618
+			calendar.UpdateDaysColors();
+		}
+	}
+
+
+	/// <summary>
 	/// Bindable property for OtherMonthSelectedDayColor
 	/// </summary>
+	[Obsolete("Use OtherMonthSelectedDayTextColorProperty instead. This alias will be removed in a future release.")]
 	public static readonly BindableProperty OtherMonthSelectedDayColorProperty = BindableProperty.Create(
 		nameof(OtherMonthSelectedDayColor),
 		typeof(Color),
@@ -101,8 +135,9 @@ public partial class Calendar : ContentView, IDisposable
 	);
 
 	/// <summary>
-	/// Specifies the color of selected days belonging to a month other than the selected one
+	/// Specifies the text color of selected days belonging to a month other than the selected one.
 	/// </summary>
+	[Obsolete("Use OtherMonthSelectedDayTextColor instead. This alias will be removed in a future release.")]
 	public Color OtherMonthSelectedDayColor
 	{
 		get => (Color)GetValue(OtherMonthSelectedDayColorProperty);
@@ -113,6 +148,8 @@ public partial class Calendar : ContentView, IDisposable
 	{
 		if (bindable is Calendar calendar)
 		{
+			// Forward to the canonical property so both names converge on the same value.
+			calendar.OtherMonthSelectedDayTextColor = (Color)newValue;
 			calendar.UpdateDaysColors();
 		}
 	}

--- a/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.Updatemethods.cs
+++ b/src/Plugin.Maui.Calendar/Shared/Controls/Calendar/Calendar.Updatemethods.cs
@@ -261,7 +261,7 @@ public partial class Calendar : ContentView, IDisposable
 			dayModel.SelectedTextColor = SelectedDayTextColor;
 			dayModel.SelectedTodayTextColor = SelectedTodayTextColor;
 			dayModel.OtherMonthColor = OtherMonthDayColor;
-			dayModel.OtherMonthSelectedColor = OtherMonthSelectedDayColor;
+			dayModel.OtherMonthSelectedColor = OtherMonthSelectedDayTextColor;
 			dayModel.WeekendDayColor = WeekendDayColor;
 			dayModel.SelectedBackgroundColor = SelectedDayBackgroundColor;
 			dayModel.TodayOutlineColor = TodayOutlineColor;


### PR DESCRIPTION
## What

Adds a new `OtherMonthSelectedDayTextColor` bindable property that sets the
text color of a selected day belonging to another month, and deprecates the
previous `OtherMonthSelectedDayColor`.

## Why

Reported in #<issue-number>: when a day from another month is selected while
using a background fill, its text "disappears". The property that controls this
text color defaults to `Silver`, which is nearly invisible on a colored
selected-day background — and it wasn't obvious because the property name was
missing the `Text` suffix that every other text-color property has
(`SelectedDayTextColor`, `DeselectedDayTextColor`, etc.).

## Changes

- Add `OtherMonthSelectedDayTextColor` as the canonical property (default `Silver`).
- Mark `OtherMonthSelectedDayColor` (and its `BindableProperty`) `[Obsolete]`.
- Two-way sync in the `propertyChanged` handlers so setting either name updates
  the other — **no breaking change**; old XAML/C# keeps working and only emits a
  deprecation warning.
- Rendering now reads the new property.
- Update sample (`SimplePage.xaml`) and README to the new name + changelog note.

## Migration

```xml
<!-- before -->
<plugin:Calendar OtherMonthSelectedDayColor="White" />

<!-- after -->
<plugin:Calendar OtherMonthSelectedDayTextColor="White" />

```



fixes #255 